### PR TITLE
Missing Imprison in arena-flyout.json

### DIFF
--- a/en/arena-flyout.json
+++ b/en/arena-flyout.json
@@ -46,5 +46,6 @@
   "fireGrassPledge": "Sea of Fire",
   "waterFirePledge": "Rainbow",
   "grassWaterPledge": "Swamp",
-  "fairyLock": "Fairy Lock"
+  "fairyLock": "Fairy Lock",
+  "imprison": "Imprison"
 }


### PR DESCRIPTION
The key that is suppsoed to display the move "Imprison" in arena-flyout was missing.